### PR TITLE
Include gems with other name than repository

### DIFF
--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -141,8 +141,7 @@ module Puck
       specs = specs.map do |bundler_spec|
         case bundler_spec.source
         when Bundler::Source::Git
-          revision = bundler_spec.source.options['revision']
-          gemspec_path = File.join(ENV['GEM_HOME'], 'bundler', 'gems', "#{bundler_spec.name}-#{revision[0, 12]}", "#{bundler_spec.name}.gemspec")
+          gemspec_path = File.join(ENV['GEM_HOME'], 'bundler', 'gems', "#{bundler_spec.source.extension_dir_name}", "#{bundler_spec.name}.gemspec")
           base_path = File.dirname(gemspec_path)
         else
           gemspec_path = File.join(ENV['GEM_HOME'], 'specifications', "#{bundler_spec.full_name}.gemspec")

--- a/spec/puck/jar_spec.rb
+++ b/spec/puck/jar_spec.rb
@@ -120,6 +120,11 @@ module Puck
             bootstrap = jar_entry_contents('jar-bootstrap.rb')
             bootstrap.should include(File.read(File.expand_path('../../../lib/puck/bootstrap.rb', __FILE__)))
           end
+
+          it 'supports gems with names that are not the same as the repository they are installed from' do
+            bootstrap = jar_entry_contents('jar-bootstrap.rb')
+            bootstrap.scan(%r{classpath:META-INF/gem.home/qu-redis-0.2.0/lib}).should have(1).item
+          end
         end
 
         context 'with custom options' do

--- a/spec/resources/example_app/Gemfile
+++ b/spec/resources/example_app/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org/'
 gem 'puma'
 gem 'grape'
 gem 'rack-contrib', git: 'https://github.com/rack/rack-contrib.git'
+gem 'qu-redis'
 
 group :extra do
   gem 'rack-cache'

--- a/spec/resources/example_app/Gemfile.lock
+++ b/spec/resources/example_app/Gemfile.lock
@@ -45,6 +45,12 @@ GEM
       spoon (~> 0.0)
     puma (2.0.1-java)
       rack (>= 1.1, < 2.0)
+    qu (0.2.0)
+      multi_json
+    qu-redis (0.2.0)
+      qu (= 0.2.0)
+      redis-namespace
+      simple_uuid
     rack (1.5.2)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -52,6 +58,9 @@ GEM
       rack (>= 0.4)
     rack-mount (0.8.3)
       rack (>= 1.0.0)
+    redis (3.1.0)
+    redis-namespace (1.5.1)
+      redis (~> 3.0, >= 3.0.4)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -60,6 +69,7 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
+    simple_uuid (0.4.0)
     slop (3.4.4)
     spoon (0.0.3)
       ffi
@@ -76,6 +86,7 @@ DEPENDENCIES
   pry
   puck!
   puma
+  qu-redis
   rack-cache
   rack-contrib!
   rspec


### PR DESCRIPTION
Use the correct path to a git dependency's source code:

[gem_home]/bundler/gems/name_of_gem
instead of:
[gem_home]/bundler/gems/[name_of_repo]

A gem has been added to the example project which has a another name than its repository. Please tell me if it seems unsuitable and I'll remove it from the PR.
