### PR TITLE
Raise an error when missing a gem's source code

### DIFF
--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -165,7 +165,7 @@ module Puck
             :bin_path => bin_path,
           }
         else
-          raise GemNotFoundError, "Missing gemspec at: #{gemspec_path}."
+          raise GemNotFoundError, "Could not package #{bundler_spec.name} because no gemspec could be found at #{gemspec_path}."
         end
       end
       specs.uniq { |s| s[:versioned_name] }


### PR DESCRIPTION
It should not be possible to build a jar without all of its dependencies. This PR suggest that an error should be raised when the source code for a gem is missing.
