### PR TITLE
Fixed minor bug + improved experience when folder/file not present

### DIFF
--- a/lib/puck/dependency_resolver.rb
+++ b/lib/puck/dependency_resolver.rb
@@ -1,4 +1,5 @@
 
+require 'stringio'
 require 'bundler'
 
 module Puck
@@ -41,7 +42,6 @@ module Puck
         begin
           line = __LINE__ + 1 # as __LINE__ represents next statement line i JRuby, and that becomes difficult to offset
           unit = scripting_container.parse(StringIO.new(<<-"EOS").to_inputstream, __FILE__, line)
-            require 'stringio'
             begin
               require 'bundler'
               gemfile, lockfile, groups = Marshal.load(String.from_java_bytes(arguments))

--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -81,6 +81,11 @@ module Puck
     def create!
       FileUtils.mkdir_p(@configuration[:build_dir])
 
+      ["bin", "lib"].each do |directory|
+        if Dir.glob("#{directory}/{*,.*}").empty?
+          raise PuckError, "Cannot build Jar: #{directory} directory not present / empty"
+        end
+      end
       Dir.mktmpdir do |tmp_dir|
         output_path = File.join(@configuration[:build_dir], @configuration[:jar_name])
         project_dir = Pathname.new(@configuration[:app_dir]).expand_path.cleanpath


### PR DESCRIPTION
The require "stringio" was placed after it was actually called. Hence it threw an error saying "NameError: uninitialized constant Puck::DependencyResolver::StringIO".
Also added a few lines of code to explicitly let the user know that the bin or the lib file was not created.