### PR TITLE
Work around an issue in Windows

### DIFF
--- a/lib/puck/bootstrap.rb
+++ b/lib/puck/bootstrap.rb
@@ -1,13 +1,12 @@
 if ARGV.any?
   file_name = ARGV.shift
   PUCK_BIN_PATH.each do |dir|
-    path = __FILE__.sub('jar-bootstrap.rb', File.join(dir, file_name))
-    if File.exists?(path)
-      $0 = path
-      load(path)
+    relative_path = File.join(dir, file_name)
+    if File.exists?("classpath:/#{relative_path}")
+      $0 = relative_path
+      load(relative_path)
       return
     end
   end
   abort(%(No "#{file_name}" in #{PUCK_BIN_PATH.join(File::PATH_SEPARATOR)}))
 end
- 

--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -138,9 +138,9 @@ module Puck
 
     def create_jar_bootstrap!(tmp_dir, gem_dependencies)
       File.open(File.join(tmp_dir, 'jar-bootstrap.rb'), 'w') do |io|
-        io.puts(%(PUCK_BIN_PATH = ['/#{JAR_APP_HOME}/bin', '/#{JAR_JRUBY_HOME}/bin']))
+        io.puts(%(PUCK_BIN_PATH = ['#{JAR_APP_HOME}/bin', '#{JAR_JRUBY_HOME}/bin']))
         gem_dependencies.each do |spec|
-          io.puts("PUCK_BIN_PATH << '/#{JAR_GEM_HOME}/#{spec[:versioned_name]}/#{spec[:bin_path]}'")
+          io.puts("PUCK_BIN_PATH << '#{JAR_GEM_HOME}/#{spec[:versioned_name]}/#{spec[:bin_path]}'")
         end
         io.puts
         gem_dependencies.each do |spec|

--- a/spec/integration/puck_spec.rb
+++ b/spec/integration/puck_spec.rb
@@ -46,7 +46,7 @@ describe 'bin/puck' do
 
   it 'outputs an error when the named script can\'t be found' do
     output = %x(#{jar_command} xyz 2>&1)
-    output.should include('No "xyz" in /META-INF/app.home/bin:/META-INF/jruby.home/bin:/META-INF/gem.home/i18n-0.6.1/bin:')
+    output.should include('No "xyz" in META-INF/app.home/bin:META-INF/jruby.home/bin:META-INF/gem.home/i18n-0.6.1/bin:')
   end
 
   it 'exposes JRuby\'s bin files' do

--- a/spec/puck/jar_spec.rb
+++ b/spec/puck/jar_spec.rb
@@ -129,7 +129,7 @@ module Puck
 
           it 'adds all gem\'s bin directories to a constant in jar-bootstrap.rb' do
             bootstrap = jar_entry_contents('jar-bootstrap.rb')
-            bootstrap.should include(%(PUCK_BIN_PATH << '/META-INF/gem.home/fake-gem-0.1.1/bin'))
+            bootstrap.should include(%(PUCK_BIN_PATH << 'META-INF/gem.home/fake-gem-0.1.1/bin'))
           end
 
           it 'adds code that will run the named bin file' do

--- a/spec/resources/example_app/bin/server
+++ b/spec/resources/example_app/bin/server
@@ -5,8 +5,8 @@ $LOAD_PATH << File.expand_path('../../lib', __FILE__)
 require 'rack/handler/puma'
 require 'example_app/hello_world'
 
-
-config = YAML.load_file(File.expand_path('../../config/app.yml', __FILE__))
+config_path = File.expand_path('../../config/app.yml', __FILE__)
+config = YAML.load_file(config_path)
 port = config['port'].to_i
 app = ExampleApp::HelloWorld.new(File.basename($0) + ": " + config['message'])
 Rack::Handler::Puma.run(app, :Port => port)


### PR DESCRIPTION
This hopefully solves #12.

`$: << File.expand_path('../../lib', __FILE__)` from an app's bin files does not work on Windows because the path ends up as "classpath:C:/META-INF/app.home/lib". It's the same on *nix but it doesn't seem to matter that the path is prefixed with just a slash.

The behaviour of File.expand_path seems to depend on not just the actual value of __FILE__, but also on how the file it's run from was loaded. That sounds very strange and I hope I'm wrong, but that's what it looks like. It does seem like when the file is loaded either as "classpath:META-INF/app.home/bin/foobar" or just "META-INF/app.home/bin/foobar" that the path returned by File.expand_path does not come out prefixed by "classpath:/", but instead a full file system + JAR path, e.g. /home/foo/bar.jar!/META-INF/app.home/lib".

I have not tested this on Windows, I'm hoping to get some help to verify that this works around the problem. The next step is figuring out how to report this as a JRuby issue.