### PR TITLE
Enable specifying a default entrypoint

### DIFF
--- a/lib/puck/bootstrap.rb
+++ b/lib/puck/bootstrap.rb
@@ -1,5 +1,6 @@
-if ARGV.any?
-  file_name = ARGV.shift
+file_name = Java::JavaLang::System.get_property('puck.entrypoint') || ARGV.shift
+
+if file_name
   PUCK_BIN_PATH.each do |dir|
     relative_path = File.join(dir, file_name)
     if File.exists?("classpath:/#{relative_path}")

--- a/spec/integration/puck_spec.rb
+++ b/spec/integration/puck_spec.rb
@@ -5,8 +5,12 @@ require 'open-uri'
 
 
 describe 'bin/puck' do
+  let :java_options do
+    []
+  end
+
   let :jar_command do
-    %(GEM_HOME='' GEM_PATH='' java -jar spec/resources/example_app/build/example_app.jar)
+    %(GEM_HOME='' GEM_PATH='' java #{java_options.join(' ')} -jar spec/resources/example_app/build/example_app.jar)
   end
 
   before :all do
@@ -57,5 +61,11 @@ describe 'bin/puck' do
   it 'exposes all gem\'s bin files' do
     output = %x(#{jar_command} rackup -h 2>&1)
     output.should include('Usage: rackup')
+  end
+
+  it 'runs the command specified by a system property' do
+    java_options << '-Dpuck.entrypoint=echo'
+    output = %x(#{jar_command} server)
+    output.should include('server')
   end
 end

--- a/spec/resources/example_app/bin/echo
+++ b/spec/resources/example_app/bin/echo
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+puts ARGV.join(' ')


### PR DESCRIPTION
I want to be able to somehow specify a default entrypoint, so that when I run
```sh
$ java -jar path/to/app.jar arg1 arg2
```
my default bin-script is run with the arguments `arg1` and `arg2`, rather than trying to run `arg1` with `arg2` as argument.

To achive this I have two potential solutions:
- The one currently implemented in this PR; use a Java system property called `puck.entrypoint` if present, otherwise use the first argument as before.
- Enable specifying the default entrypoint at build time; if no default entrypoint is specified, behave as before, and if explicitly specified behave like
```sh
$ java -jar path/to/app.jar arg1 arg2 # run default script with arg1 and arg2
$ java -jar path/to/app.jar other-script -- arg1 arg2 # run other-script with arg1 and arg2
$ java -jar path/to/app.jar other-script arg1 -- arg2 # fail due to invalid arguments
```

The main benefits of the former solution is that it is the least intrusive to Puck and probably easiest to understand. The latter is a bit more convinient to run since the user doesn't have to write `-Dpuck.entrypoint=bin-script`. It also doesn't depend on the user's knowledge of the magic property name `puck.entrypoint`.

The reason for why I want this at all is that I want to run my Puck packed JARs in Hadoop, which obviously knows nothing about the names of my bin-scripts.
