### PR TITLE
Exit instead of return from bootstrap

### DIFF
--- a/lib/puck/bootstrap.rb
+++ b/lib/puck/bootstrap.rb
@@ -5,7 +5,7 @@ if ARGV.any?
     if File.exists?("classpath:/#{relative_path}")
       $0 = relative_path
       load(relative_path)
-      return
+      exit
     end
   end
   abort(%(No "#{file_name}" in #{PUCK_BIN_PATH.join(File::PATH_SEPARATOR)}))


### PR DESCRIPTION
In JRuby 9k this fails with an exception like
```
LocalJumpError: unexpected return
  block in classpath:jar-bootstrap.rb at classpath:jar-bootstrap.rb:119
                                 each at org/jruby/RubyArray.java:1560
                                <top> at classpath:jar-bootstrap.rb:114
```
Not sure why this worked in earlier versions of JRuby.