### PR TITLE
Custom extra files paths

### DIFF
--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -100,46 +100,49 @@ module Puck
         create_jar_bootstrap!(tmp_dir, gem_dependencies)
 
         ant = Ant.new(output_level: 1)
-        ant.jar(destfile: output_path) do
-          manifest do
-            attribute name: 'Main-Class', value: 'org.jruby.JarBootstrapMain'
-            attribute name: 'Created-By', value: "Puck v#{Puck::VERSION}"
-          end
-
-          zipfileset dir: tmp_dir, includes: 'jar-bootstrap.rb'
-
-          if jruby_complete_path
-            zipfileset src: jruby_complete_path
-          else
-            zipfileset src: JRubyJars.core_jar_path
-            zipfileset src: JRubyJars.stdlib_jar_path
-          end
-
-          %w[bin lib].each do |sub_dir|
-            path = project_dir + sub_dir
-            if File.exists?(path)
-              zipfileset dir: path, prefix: File.join(JAR_APP_HOME, sub_dir)
+        begin
+          ant.jar(destfile: output_path) do
+            manifest do
+              attribute name: 'Main-Class', value: 'org.jruby.JarBootstrapMain'
+              attribute name: 'Created-By', value: "Puck v#{Puck::VERSION}"
             end
-          end
 
-          extra_files.each do |file, target_path|
-            path = Pathname.new(file).expand_path.cleanpath
-            if target_path
-              zipfileset file: path, fullpath: target_path
+            zipfileset dir: tmp_dir, includes: 'jar-bootstrap.rb'
+
+            if jruby_complete_path
+              zipfileset src: jruby_complete_path
             else
-              prefix = File.join(JAR_APP_HOME, path.relative_path_from(project_dir).dirname.to_s)
-              zipfileset dir: path.dirname, prefix: prefix, includes: path.basename
+              zipfileset src: JRubyJars.core_jar_path
+              zipfileset src: JRubyJars.stdlib_jar_path
             end
-          end
 
-          gem_dependencies.each do |spec|
-            base_path = Pathname.new(spec[:base_path]).expand_path.cleanpath
-            unless project_dir == base_path
-              zipfileset dir: spec[:base_path], prefix: File.join(JAR_GEM_HOME, spec[:versioned_name])
+            %w[bin lib].each do |sub_dir|
+              path = project_dir + sub_dir
+              if File.exists?(path)
+                zipfileset dir: path, prefix: File.join(JAR_APP_HOME, sub_dir)
+              end
+            end
+
+            extra_files.each do |file, target_path|
+              path = Pathname.new(file).expand_path.cleanpath
+              if target_path
+                zipfileset file: path, fullpath: target_path
+              else
+                prefix = File.join(JAR_APP_HOME, path.relative_path_from(project_dir).dirname.to_s)
+                zipfileset dir: path.dirname, prefix: prefix, includes: path.basename
+              end
+            end
+
+            gem_dependencies.each do |spec|
+              base_path = Pathname.new(spec[:base_path]).expand_path.cleanpath
+              unless project_dir == base_path
+                zipfileset dir: spec[:base_path], prefix: File.join(JAR_GEM_HOME, spec[:versioned_name])
+              end
             end
           end
+        rescue Java::OrgApacheToolsAnt::BuildException => e
+          raise PuckError, sprintf('Error when building JAR: %s (%s)', e.message, e.class), e.backtrace
         end
-
         output_path
       end
     end

--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -49,7 +49,9 @@ module Puck
     #
     # @param [Hash] configuration
     # @option configuration [String] :extra_files a list of files to include in
-    #   the Jar. The paths must be below the `:app_dir`.
+    #   the Jar. The option can be either an Array, in which case paths must be
+    #   below the `:app_dir`, or a Hash, in which case the file specified by the
+    #   key is included at the path specified by the corresponding value.
     # @option configuration [String] :gem_groups ([:default]) a list of gem
     #   groups to include in the Jar. Remember to include the default group if
     #   you override this option.
@@ -119,10 +121,10 @@ module Puck
             end
           end
 
-          extra_files.each do |ef|
-            path = Pathname.new(ef).expand_path.cleanpath
-            prefix = File.join(JAR_APP_HOME, path.relative_path_from(project_dir).dirname.to_s)
-            zipfileset dir: path.dirname, prefix: prefix, includes: path.basename
+          extra_files.each do |file, target_path|
+            path = Pathname.new(file).expand_path.cleanpath
+            target_path ||= File.join(JAR_APP_HOME, path.relative_path_from(project_dir))
+            zipfileset file: path, fullpath: target_path
           end
 
           gem_dependencies.each do |spec|

--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -123,8 +123,12 @@ module Puck
 
           extra_files.each do |file, target_path|
             path = Pathname.new(file).expand_path.cleanpath
-            target_path ||= File.join(JAR_APP_HOME, path.relative_path_from(project_dir))
-            zipfileset file: path, fullpath: target_path
+            if target_path
+              zipfileset file: path, fullpath: target_path
+            else
+              prefix = File.join(JAR_APP_HOME, path.relative_path_from(project_dir).dirname.to_s)
+              zipfileset dir: path.dirname, prefix: prefix, includes: path.basename
+            end
           end
 
           gem_dependencies.each do |spec|

--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -48,10 +48,11 @@ module Puck
     # is the same as the name of the directory containing the "lib" directory.
     #
     # @param [Hash] configuration
-    # @option configuration [String] :extra_files a list of files to include in
-    #   the Jar. The option can be either an Array, in which case paths must be
-    #   below the `:app_dir`, or a Hash, in which case the file specified by the
-    #   key is included at the path specified by the corresponding value.
+    # @option configuration [Array<String>, Hash<String,String>] :extra_files a
+    #   list of files to include in the Jar. The option can be either an Array,
+    #   in which case paths must be below the `:app_dir`, or a Hash, in which
+    #   case the file specified by the key is included at the path specified by
+    #   the corresponding value.
     # @option configuration [String] :gem_groups ([:default]) a list of gem
     #   groups to include in the Jar. Remember to include the default group if
     #   you override this option.

--- a/spec/puck/jar_spec.rb
+++ b/spec/puck/jar_spec.rb
@@ -148,19 +148,39 @@ module Puck
           end
 
           context 'with extra files' do
-            it 'preserves relative paths for array argument' do
-              create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: %w[config/app.yml])
-              jar_entries.should include('META-INF/app.home/config/app.yml')
+            context 'when the argument is an array' do
+              it 'preserves relative paths' do
+                create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: %w[config/app.yml])
+                jar_entries.should include('META-INF/app.home/config/app.yml')
+              end
+
+              it 'is possible to include files using globs' do
+                create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: %w[config/*.yml])
+                jar_entries.should include('META-INF/app.home/config/app.yml', 'META-INF/app.home/config/another.yml')
+              end
             end
 
-            it 'is possible to include files using globs' do
-              create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: %w[config/*.yml])
-              jar_entries.should include('META-INF/app.home/config/app.yml', 'META-INF/app.home/config/another.yml')
-            end
+            context 'when the argument is a hash' do
+              it 'uses the keys for the path of the content and the value as the path within the JAR' do
+                create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: {'config/app.yml' => 'specified/path.yml'})
+                jar_entries.should include('specified/path.yml')
+              end
 
-            it 'uses specified paths for hash argument' do
-              create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: {'config/app.yml' => 'specified/path.yml'})
-              jar_entries.should include('specified/path.yml')
+              it 'is not possible to include files using globs' do
+                expect { create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: {'config/*.yml' => 'specified/path.yml'}) }.to raise_error(PuckError)
+              end
+
+              context 'when the value is nil' do
+                it 'preserves relative paths' do
+                  create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: {'config/app.yml' => nil})
+                  jar_entries.should include('META-INF/app.home/config/app.yml')
+                end
+
+                it 'is possible to include files using globs' do
+                  create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: {'config/*.yml' => nil})
+                  jar_entries.should include('META-INF/app.home/config/app.yml', 'META-INF/app.home/config/another.yml')
+                end
+              end
             end
           end
 

--- a/spec/puck/jar_spec.rb
+++ b/spec/puck/jar_spec.rb
@@ -153,6 +153,11 @@ module Puck
               jar_entries.should include('META-INF/app.home/config/app.yml')
             end
 
+            it 'is possible to include files using globs' do
+              create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: %w[config/*.yml])
+              jar_entries.should include('META-INF/app.home/config/app.yml', 'META-INF/app.home/config/another.yml')
+            end
+
             it 'uses specified paths for hash argument' do
               create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: {'config/app.yml' => 'specified/path.yml'})
               jar_entries.should include('specified/path.yml')

--- a/spec/puck/jar_spec.rb
+++ b/spec/puck/jar_spec.rb
@@ -147,9 +147,16 @@ module Puck
             @tmp_dir = Dir.mktmpdir
           end
 
-          it 'includes extra files' do
-            create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: %w[config/app.yml])
-            jar_entries.should include('META-INF/app.home/config/app.yml')
+          context 'with extra files' do
+            it 'preserves relative paths for array argument' do
+              create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: %w[config/app.yml])
+              jar_entries.should include('META-INF/app.home/config/app.yml')
+            end
+
+            it 'uses specified paths for hash argument' do
+              create_jar(@tmp_dir, dependency_resolver: dependency_resolver, extra_files: {'config/app.yml' => 'specified/path.yml'})
+              jar_entries.should include('specified/path.yml')
+            end
           end
 
           it 'uses an alternative jruby-complete.jar' do

--- a/spec/resources/example_app/config/another.yml
+++ b/spec/resources/example_app/config/another.yml
@@ -1,0 +1,2 @@
+message: Olleh Dlrow
+port: 4433


### PR DESCRIPTION
This PR suggests enabling users to specify the paths of extra files added to the JAR. The proposed interface is:

```ruby
# old behavior is preserved:
Jar.new(extra_files: %w[file/in/app-home.txt], ...)

 # include file.txt in jar!relative/path.txt:
Jar.new(extra_files: {'/any/file.txt' => 'relative/path.txt'}, ...)
```

The motivation is giving users (read me) more control over the structure of the resulting JAR.

The current implementation allows specifying `nil` as target path, in which case the old method and put the file in the app home.