### PR TITLE
Run tests for multiple Bundler versions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: ruby
 sudo: false
+before_install: gem install bundler --version "$BUNDLER_VERSION"
 script: bundle exec rake spec
 rvm:
   - jruby
+# these JRuby jarss/Bundler combinations are chosen arbitrarily to enable
+# testing a bunch of versions without producing a huge build matrix
 env:
-  - JRUBY_JARS_VERSION=1.7.19
-  - JRUBY_JARS_VERSION=1.7.21
-  - JRUBY_JARS_VERSION=1.7.23
+  - JRUBY_JARS_VERSION=1.7.19 BUNDLER_VERSION="~> 1.7.0"
+  - JRUBY_JARS_VERSION=1.7.21 BUNDLER_VERSION="~> 1.9.0"
+  - JRUBY_JARS_VERSION=1.7.23 BUNDLER_VERSION="~> 1.11.0"
 matrix:
   include:
     - rvm: jruby-9.0.4.0

--- a/lib/puck/dependency_resolver.rb
+++ b/lib/puck/dependency_resolver.rb
@@ -26,6 +26,7 @@ module Puck
           :base_path => base_path,
           :load_paths => load_paths,
           :bin_path => spec[:bindir],
+          :spec_file => spec[:spec_file],
         }
       end
     end
@@ -54,6 +55,7 @@ module Puck
                   :full_gem_path => gem_spec.full_gem_path,
                   :load_paths => gem_spec.load_paths,
                   :bindir => gem_spec.bindir,
+                  :spec_file => gem_spec.loaded_from,
                 }
               end
               Marshal.dump([specs]).to_java_bytes

--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -144,7 +144,8 @@ module Puck
             gem_dependencies.each do |spec|
               base_path = Pathname.new(spec[:base_path]).expand_path.cleanpath
               unless project_dir == base_path
-                zipfileset dir: spec[:base_path], prefix: File.join(JAR_GEM_HOME, spec[:versioned_name])
+                zipfileset dir: spec[:base_path], prefix: File.join(JAR_GEM_HOME, 'gems', spec[:versioned_name])
+                zipfileset file: spec[:spec_file], fullpath: File.join(JAR_GEM_HOME, 'specifications', File.basename(spec[:spec_file]))
               end
             end
 
@@ -184,14 +185,10 @@ module Puck
         io.puts(%(PUCK_ROOT = JRuby.runtime.jruby_class_loader.get_resource('jar-bootstrap.rb').to_s.chomp('jar-bootstrap.rb')))
         io.puts(%(PUCK_BIN_PATH = ['#{JAR_APP_HOME}/bin', '#{JAR_JRUBY_HOME}/bin']))
         gem_dependencies.each do |spec|
-          io.puts("PUCK_BIN_PATH << '#{JAR_GEM_HOME}/#{spec[:versioned_name]}/#{spec[:bin_path]}'")
+          io.puts("PUCK_BIN_PATH << '#{JAR_GEM_HOME}/gems/#{spec[:versioned_name]}/#{spec[:bin_path]}'")
         end
         io.puts
-        gem_dependencies.each do |spec|
-          spec[:load_paths].each do |load_path|
-            io.puts(%($LOAD_PATH << File.join(PUCK_ROOT, '#{JAR_GEM_HOME}/#{spec[:versioned_name]}/#{load_path}')))
-          end
-        end
+        io.puts(%(Gem.paths = {'GEM_HOME' => File.join(PUCK_ROOT, '#{JAR_GEM_HOME}')}))
         io.puts
         io.puts(File.read(File.expand_path('../bootstrap.rb', __FILE__)))
       end

--- a/spec/integration/puck_spec.rb
+++ b/spec/integration/puck_spec.rb
@@ -88,4 +88,10 @@ describe 'bin/puck' do
     output = isolated_run(jar_command('rackup -h'))
     output.should include('Usage: rackup')
   end
+
+  it 'is possible to find specific versions of gems with Kernel#gem' do
+    gem_command = 'gem("json", "=1.8.1")'
+    output = isolated_run(sprintf("echo '%s' | %s", gem_command, jar_command('irb')))
+    output.should include(sprintf("%s\ntrue\n", gem_command))
+  end
 end

--- a/spec/puck/dependency_resolver_spec.rb
+++ b/spec/puck/dependency_resolver_spec.rb
@@ -57,6 +57,12 @@ module Puck
         load_paths.grep(%r{i18n-[\d.]+/bin}).should_not be_empty
       end
 
+      it 'includes the path to the loaded gem specification' do
+        gem_spec_files = resolved_gem_dependencies.map { |gem| gem[:spec_file] }
+        gem_spec_files.grep(%r{example_dep/example_dep.gemspec}).should_not be_empty
+        gem_spec_files.grep(%r{specifications/i18n-[\d.]+.gemspec}).should_not be_empty
+      end
+
       it 'correctly handles gems with a specific platform' do
         specification = resolved_gem_dependencies.find { |gem| gem[:name] == 'puma' }
         File.basename(specification[:base_path]).should match(/puma-[\d.]+-java/)

--- a/spec/puck/jar_spec.rb
+++ b/spec/puck/jar_spec.rb
@@ -42,6 +42,7 @@ module Puck
               :base_path => @base_path,
               :load_paths => %w[lib],
               :bin_path => 'bin',
+              :spec_file => File.join(@base_path, 'fake-gem.gemspec'),
             },
             {
               :name => 'example_app',
@@ -49,6 +50,7 @@ module Puck
               :base_path => File.expand_path('.'),
               :load_paths => %w[lib],
               :bin_path => 'bin',
+              :spec_file => File.expand_path('example-app.gemspec'),
             }
           ]
         end
@@ -61,6 +63,7 @@ module Puck
           File.write('bin/fake', 'require "fake"')
           Dir.mkdir('lib')
           File.write('lib/fake.rb', 'exit 2')
+          File.write('fake-gem.gemspec', '')
         end
       end
 
@@ -104,31 +107,35 @@ module Puck
             jar_entries.should include('META-INF/jruby.home/lib/ruby/1.9/pp.rb')
           end
 
-          it 'puts gems into META-INF/gem.home' do
-            jar_entries.should include('META-INF/gem.home/fake-gem-0.1.1/bin/fake')
-            bin = jar_entry_contents('META-INF/gem.home/fake-gem-0.1.1/bin/fake')
+          it 'puts gems into META-INF/gem.home/gems' do
+            jar_entries.should include('META-INF/gem.home/gems/fake-gem-0.1.1/bin/fake')
+            bin = jar_entry_contents('META-INF/gem.home/gems/fake-gem-0.1.1/bin/fake')
             bin.should == 'require "fake"'
-            jar_entries.should include('META-INF/gem.home/fake-gem-0.1.1/lib/fake.rb')
-            lib = jar_entry_contents('META-INF/gem.home/fake-gem-0.1.1/lib/fake.rb')
+            jar_entries.should include('META-INF/gem.home/gems/fake-gem-0.1.1/lib/fake.rb')
+            lib = jar_entry_contents('META-INF/gem.home/gems/fake-gem-0.1.1/lib/fake.rb')
             lib.should == 'exit 2'
           end
 
+          it 'puts gemspecs into META-INF/gem.home/specifications' do
+            jar_entries.should include('META-INF/gem.home/specifications/fake-gem.gemspec')
+          end
+
           it 'does not bundle the project as a gem, as it should already be included' do
-            jar_entries.grep(%r{META-INF/gem.home/example_app-}).should be_empty
+            jar_entries.grep(%r{META-INF/gem.home/gems/example_app-}).should be_empty
           end
 
           it 'creates a jar-bootstrap.rb and puts it in the root of the JAR' do
             jar_entries.should include('jar-bootstrap.rb')
           end
 
-          it 'adds all gems to the load path in jar-bootstrap.rb' do
+          it 'sets GEM_HOME in jar-bootstrap.rb' do
             bootstrap = jar_entry_contents('jar-bootstrap.rb')
-            bootstrap.should include(%($LOAD_PATH << File.join(PUCK_ROOT, 'META-INF/gem.home/fake-gem-0.1.1/lib')))
+            bootstrap.should include(%|Gem.paths = {'GEM_HOME' => File.join(PUCK_ROOT, 'META-INF/gem.home')}|)
           end
 
           it 'adds all gem\'s bin directories to a constant in jar-bootstrap.rb' do
             bootstrap = jar_entry_contents('jar-bootstrap.rb')
-            bootstrap.should include(%(PUCK_BIN_PATH << 'META-INF/gem.home/fake-gem-0.1.1/bin'))
+            bootstrap.should include(%(PUCK_BIN_PATH << 'META-INF/gem.home/gems/fake-gem-0.1.1/bin'))
           end
 
           it 'adds code that will run the named bin file' do

--- a/spec/resources/example_app/Gemfile
+++ b/spec/resources/example_app/Gemfile
@@ -5,6 +5,7 @@ gemspec name: 'example'
 gem 'puma'
 gem 'rack-contrib', git: 'https://github.com/rack/rack-contrib.git'
 gem 'qu-redis'
+gem 'json', '= 1.8.1'
 
 gem 'puck-example_dep', path: '../example_dep'
 

--- a/spec/resources/example_app/Gemfile.lock
+++ b/spec/resources/example_app/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     hashie (2.0.4)
     i18n (0.6.1)
     jruby-jars (1.7.11)
+    json (1.8.1-java)
     method_source (0.8.1)
     multi_json (1.7.2)
     multi_xml (0.5.3)
@@ -96,6 +97,7 @@ PLATFORMS
 
 DEPENDENCIES
   jruby-jars (= 1.7.11)
+  json (= 1.8.1)
   pry
   puck!
   puck-example_app!


### PR DESCRIPTION
Prior to merging #20, the tests were failing on master. I blamed that on Travis updating Bundler, but I was never really sure. This is one attempt of running the tests for multiple Bundler versions to highlight any such issues.

However, the tests appear to be passing for all tested versions atm, so I don't really know the value anymore. Thoughts?

And also, does anyone have any good ideas on how I should get Travis to install the latest Bundler? One solution would be `BUNDLER_VERSION="~> 1"` I guess, but there must be a better way.