### PR TITLE
Properly respect `app_dir` in DependencyResolver

### DIFF
--- a/lib/puck/dependency_resolver.rb
+++ b/lib/puck/dependency_resolver.rb
@@ -65,7 +65,7 @@ module Puck
           if error
             arity = error.method(:new).arity
             if arity > 1 || arity < 0
-              raise RuntimeError, error.name + ': ' + message, Array(backtrace)+caller
+              raise RuntimeError, '%s: %s' % [error.name, message], Array(backtrace)+caller
             else
               raise error, message, Array(backtrace)+caller
             end

--- a/lib/puck/dependency_resolver.rb
+++ b/lib/puck/dependency_resolver.rb
@@ -5,12 +5,13 @@ module Puck
   # @private
   class DependencyResolver
     def resolve_gem_dependencies(options = {})
+      app_dir = options[:app_dir] || Dir.pwd
       gem_home = options[:gem_home] || ENV['GEM_HOME']
-      gemfile = options[:gemfile] || File.expand_path('Gemfile', options[:app_dir] || Dir.pwd)
+      gemfile = options[:gemfile] || File.expand_path('Gemfile', app_dir)
       lockfile = options[:lockfile] || "#{gemfile}.lock"
       groups = options[:gem_groups] || [:default]
 
-      bundler_specs = contained_bundler(gem_home, gemfile, lockfile, groups)
+      bundler_specs = contained_bundler(gem_home, gemfile, lockfile, groups, app_dir)
       bundler_specs.delete_if { |spec| spec[:name] == 'bundler' }
       bundler_specs.map do |spec|
         base_path = spec[:full_gem_path].chomp('/')
@@ -32,11 +33,11 @@ module Puck
 
     private
 
-    def contained_bundler(gem_home, gemfile, lockfile, groups)
+    def contained_bundler(gem_home, gemfile, lockfile, groups, app_dir)
       Bundler.with_clean_env do
         scripting_container = Java::OrgJrubyEmbed::ScriptingContainer.new(Java::OrgJrubyEmbed::LocalContextScope::SINGLETHREAD)
         scripting_container.compat_version = Java::OrgJruby::CompatVersion::RUBY1_9
-        scripting_container.current_directory = Dir.pwd
+        scripting_container.current_directory = app_dir
         scripting_container.environment = Hash[ENV.merge('GEM_HOME' => gem_home).map { |k,v| [k.to_java, v.to_java] }]
         scripting_container.put('arguments', Marshal.dump([gemfile, lockfile, groups]).to_java_bytes)
         begin

--- a/lib/puck/dependency_resolver.rb
+++ b/lib/puck/dependency_resolver.rb
@@ -63,7 +63,12 @@ module Puck
           EOS
           result, error, message, backtrace = Marshal.load(String.from_java_bytes(unit.run))
           if error
-            raise error, message, Array(backtrace)+caller
+            arity = error.method(:new).arity
+            if arity > 1 || arity < 0
+              raise RuntimeError, error.name + ': ' + message, Array(backtrace)+caller
+            else
+              raise error, message, Array(backtrace)+caller
+            end
           end
           result
         ensure

--- a/lib/puck/dependency_resolver.rb
+++ b/lib/puck/dependency_resolver.rb
@@ -63,8 +63,7 @@ module Puck
           EOS
           result, error, message, backtrace = Marshal.load(String.from_java_bytes(unit.run))
           if error
-            arity = error.method(:new).arity
-            if arity > 1 || arity < 0
+            if error.method(:new).arity != 1
               raise RuntimeError, '%s: %s' % [error.name, message], Array(backtrace)+caller
             else
               raise error, message, Array(backtrace)+caller

--- a/spec/puck/dependency_resolver_spec.rb
+++ b/spec/puck/dependency_resolver_spec.rb
@@ -110,6 +110,26 @@ module Puck
           bundler_config.should_not exist
         end
       end
+
+      context 'with custom app_dir' do
+        let :resolved_gem_dependencies do
+          described_class.new.resolve_gem_dependencies(options)
+        end
+
+        let :options do
+          super.merge(app_dir: app_dir_path)
+        end
+
+        it 'does not fail to find dependencies' do
+          expect { resolved_gem_dependencies }.to_not raise_error
+        end
+
+        it 'does not write a bundle configuration' do
+          resolved_gem_dependencies # force evaluation
+          bundler_config = Pathname.new(app_dir_path).join('.bundle', 'config')
+          bundler_config.should_not exist
+        end
+      end
     end
   end
 end

--- a/spec/puck/dependency_resolver_spec.rb
+++ b/spec/puck/dependency_resolver_spec.rb
@@ -7,9 +7,7 @@ module Puck
   describe DependencyResolver do
     describe '#resolve_gem_dependencies' do
       let :resolved_gem_dependencies do
-        Dir.chdir(app_dir_path) do
-          described_class.new.resolve_gem_dependencies(options)
-        end
+        described_class.new.resolve_gem_dependencies(options)
       end
 
       let :app_dir_path do
@@ -23,6 +21,7 @@ module Puck
       let :options do
         {
           gem_home: gem_home,
+          app_dir: app_dir_path,
         }
       end
 
@@ -111,13 +110,17 @@ module Puck
         end
       end
 
-      context 'with custom app_dir' do
+      context 'without a custom app_dir' do
         let :resolved_gem_dependencies do
-          described_class.new.resolve_gem_dependencies(options)
+          Dir.chdir(app_dir_path) do
+            described_class.new.resolve_gem_dependencies(options)
+          end
         end
 
         let :options do
-          super.merge(app_dir: app_dir_path)
+          {
+            gem_home: gem_home,
+          }
         end
 
         it 'does not fail to find dependencies' do

--- a/spec/puck/dependency_resolver_spec.rb
+++ b/spec/puck/dependency_resolver_spec.rb
@@ -105,6 +105,7 @@ module Puck
         end
 
         it 'does not write a bundle configuration' do
+          resolved_gem_dependencies # force evaluation
           bundler_config = Pathname.new(app_dir_path).join('.bundle', 'config')
           bundler_config.should_not exist
         end


### PR DESCRIPTION
Ran into a slight issue when I was trying to create a JAR using Jara from a subdirectory of a repository. Puck seems unable to find the Gemfile or `.bundle/` directory, as pointed out by the stacktrace below.

```
$ rake build:test
rake aborted!
Bundler::GemfileNotFound: Could not locate Gemfile or .bundle/ directory
/dev/repo/subdir/vendor/bundle/jruby/1.9/gems/puck-1.0.0-java/lib/puck/dependency_resolver.rb:48:in `(root)'
:1:in `'
:1:in `'
/dev/repo/subdir/vendor/bundle/jruby/1.9/gems/puck-1.0.0-java/lib/puck/dependency_resolver.rb:36:in `contained_bundler'
/dev/repo/subdir/vendor/bundle/jruby/1.9/gems/puck-1.0.0-java/lib/puck/dependency_resolver.rb:13:in `resolve_gem_dependencies'
/dev/repo/subdir/vendor/bundle/jruby/1.9/gems/puck-1.0.0-java/lib/puck/jar.rb:96:in `create'
/dev/repo/subdir/vendor/bundle/jruby/1.9/gems/puck-1.0.0-java/lib/puck/jar.rb:86:in `create'
/dev/repo/subdir/vendor/bundle/jruby/1.9/gems/puck-1.0.0-java/lib/puck/jar.rb:142:in `create!'
/dev/repo/subdir/vendor/bundle/jruby/1.9/gems/jara-2.1.0/lib/jara/releaser.rb:240:in `create'
/dev/repo/subdir/vendor/bundle/jruby/1.9/gems/jara-2.1.0/lib/jara/releaser.rb:35:in `build_artifact'
/dev/repo/subdir/vendor/bundle/jruby/1.9/gems/jara-2.1.0/lib/jara/releaser.rb:34:in `chdir'
/dev/repo/subdir/vendor/bundle/jruby/1.9/gems/jara-2.1.0/lib/jara/releaser.rb:34:in `build_artifact'
/dev/repo/subdir/Rakefile:37:in `(root)'
Tasks: TOP => build:test
(See full trace by running task with --trace)
``` 

The code I'm using for building the artifact looks something like this:

```ruby
# in subdir/Rakefile
namespace :build do
  desc 'Build an artifact for test environment'
  task 'test' do
    options = {
      app_name: 'subdir_app',
      archiver_options: {
        app_dir: File.expand_path('../../subdir', __FILE__)
      }
    }
    releaser = Jara::Releaser.new(nil, nil, options)
    releaser.build_artifact
  end
end
```

Puck correctly uses `app_dir` for referencing where the Gemfile is, though it sets the current working directory of the scripting container to `Dir.pwd` which will refer to the root of the repository when using Puck through Jara. So the solution is to use `app_dir` as the current working directory.

Also noticed that there was a test in `DependencyResolver` that actually never ran any code in Puck, so I fixed that as well (though not the nicest solution, but the minimal one).