### PR TITLE
Don't raise error when JRubyJars is not installed

### DIFF
--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -99,14 +99,15 @@ module Puck
         temporary_output_path = File.join(Dir.mktmpdir, @configuration[:jar_name])
         project_dir = Pathname.new(@configuration[:app_dir]).expand_path.cleanpath
         extra_files = @configuration[:extra_files] || []
+        jruby_complete_path = @configuration[:jruby_complete]
 
         if !(defined? JRubyJars) && !(jruby_complete_path && File.exists?(jruby_complete_path))
           raise PuckError, 'Cannot build Jar: jruby-jars must be installed, or :jruby_complete must be specified'
         end
 
         merge_archives = (@configuration[:merge_archives] || []).to_a
-        if (jruby_complete = @configuration[:jruby_complete])
-          merge_archives << jruby_complete
+        if jruby_complete_path
+          merge_archives << jruby_complete_path
         else
           merge_archives.push(JRubyJars.core_jar_path, JRubyJars.stdlib_jar_path)
         end

--- a/spec/puck/jar_spec.rb
+++ b/spec/puck/jar_spec.rb
@@ -222,6 +222,14 @@ module Puck
             dependency_resolver.should_receive(:resolve_gem_dependencies).with(hash_including(gem_groups: [:default, :extra])).and_return([])
             create_jar(@tmp_dir, dependency_resolver: dependency_resolver, gem_groups: [:default, :extra])
           end
+
+          context 'when JRubyJars could not be loaded and no alternative jruby jar is provided' do
+            it 'raises an error' do
+              const = Object.send(:remove_const, :JRubyJars)
+              expect { create_jar(@tmp_dir, dependency_resolver: FakeDependencyResolver.new(@fake_gem_dir)) }.to raise_error(PuckError)
+              Object.const_set(:JRubyJars, const)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
The current implementation will raise an error when JRubyJars is not installed even though an alternative JRuby jar path has been provided. This PR adds a spec, which would have captured this bug before it was introduced in https://github.com/iconara/puck/pull/23, as well as a fix for it.
