### PR TITLE
Make load paths absolute

### DIFF
--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -188,7 +188,7 @@ module Puck
         io.puts
         gem_dependencies.each do |spec|
           spec[:load_paths].each do |load_path|
-            io.puts(%($LOAD_PATH << 'classpath:#{JAR_GEM_HOME}/#{spec[:versioned_name]}/#{load_path}'))
+            io.puts(%($LOAD_PATH << 'classpath:/#{JAR_GEM_HOME}/#{spec[:versioned_name]}/#{load_path}'))
           end
         end
         io.puts

--- a/spec/puck/jar_spec.rb
+++ b/spec/puck/jar_spec.rb
@@ -123,7 +123,7 @@ module Puck
 
           it 'adds all gems to the load path in jar-bootstrap.rb' do
             bootstrap = jar_entry_contents('jar-bootstrap.rb')
-            bootstrap.should include(%($LOAD_PATH << 'classpath:META-INF/gem.home/fake-gem-0.1.1/lib'))
+            bootstrap.should include(%($LOAD_PATH << 'classpath:/META-INF/gem.home/fake-gem-0.1.1/lib'))
           end
 
           it 'adds all gem\'s bin directories to a constant in jar-bootstrap.rb' do


### PR DESCRIPTION
Paths starting with 'classpath' should be absolute, otherwise JRuby fails to read files from inside the archive. I guess it works to require source files, but for some reason not read normal files. For example aws-sdk-v1 tries to load a json-file with a path based on it's `__FILE__` path and fails.

These commands demonstrate why the paths needs to be absolute. The first fails while the second works.

```
$ jruby -e 'puts File.read("classpath:META-INF/LICENSE.txt")'
$ jruby -e 'puts File.read("classpath:/META-INF/LICENSE.txt")'
```