### PR TITLE
Don't do Kernel.exit from bootstrap.rb

### DIFF
--- a/lib/puck/bootstrap.rb
+++ b/lib/puck/bootstrap.rb
@@ -1,12 +1,16 @@
 if ARGV.any?
   file_name = ARGV.shift
+  bin_file_found = false
   PUCK_BIN_PATH.each do |dir|
     relative_path = File.join(dir, file_name)
     if File.exists?("classpath:/#{relative_path}")
+      bin_file_found = true
       $0 = relative_path
       load(relative_path)
-      exit
+      break
     end
   end
-  abort(%(No "#{file_name}" in #{PUCK_BIN_PATH.join(File::PATH_SEPARATOR)}))
+  unless bin_file_found
+    abort(%(No "#{file_name}" in #{PUCK_BIN_PATH.join(File::PATH_SEPARATOR)}))
+  end
 end


### PR DESCRIPTION
It's not obvious that we want to exit just because the thread that ran jar-bootstrap.rb has finished.

In Rubydoop, the bootstrap-file is loaded on the task-nodes to set up the load path after which we don't want to exit.