### PR TITLE
Make it possible to execute Ruby code that is not bundled in the JAR

### DIFF
--- a/spec/integration/puck_spec.rb
+++ b/spec/integration/puck_spec.rb
@@ -84,7 +84,7 @@ describe 'bin/puck' do
     end
   end
 
-  it 'exposes all gem\'s bin files' do
+  it 'exposes all gems\' bin files' do
     output = isolated_run(jar_command('rackup -h'))
     output.should include('Usage: rackup')
   end

--- a/spec/integration/puck_spec.rb
+++ b/spec/integration/puck_spec.rb
@@ -88,4 +88,24 @@ describe 'bin/puck' do
     output = isolated_run(jar_command('rackup -h'))
     output.should include('Usage: rackup')
   end
+
+  it 'allows running arbitrary Ruby code' do
+    output = isolated_run(jar_command(%q<ruby -e 'puts "Hello World"'>))
+    output.should include('Hello World')
+  end
+
+  it 'can tell you which version of JRuby that is bundled' do
+    output = isolated_run(jar_command(%q<ruby -v>))
+    output.should include('jruby 1.7.12')
+  end
+
+  it 'allows running arbitrary Ruby files and makes all bundled gems available' do
+    Tempfile.open('script') do |tio|
+      tio.puts('require "rack"')
+      tio.puts('puts "Rack: #{Rack.version}"')
+      tio.close
+      output = isolated_run(jar_command(%<ruby #{tio.path}>))
+      output.should include('Rack: 1.5.2')
+    end
+  end
 end


### PR DESCRIPTION
_This is a proposal that so far only contains failing test cases that demonstrate the proposed feature._

I want to make it possible to use the Ruby runtime and gems in the JAR to run code that is not bundled in it. Sometimes you all you have is the JAR, but you need to run a one-off script that uses the gems in the JAR. Unpacking the thing is possible, and it's also possible to put the things inside of it on the load path of a script, but it's not very convenient.

What would be convenient is to be able to run `java -jar path/to.jar ruby -e 'puts "Hello world"'` or `java -jar path/to.jar ruby path/to/script.rb`.

In order not to create a leaky abstraction, this should ideally be the same actual code that is run as when you run just `ruby -e …`, `ruby -v`, etc. If this is not possible to achieve perhaps it would be better to skip the "ruby" part of it and make it work like `java -jar path/to.jar -e "…"`. Since no bin files should start with a dash I think that could work too.

Initially I tried just running `org.jruby.Main.main(ARGV)` in `bootstrap.rb` when `$0` was `"ruby"`, but that starts up a new runtime, so even if `-e` works it won't have easy access to the gems in the JAR.