### PR TITLE
Prefer user installed gems

### DIFF
--- a/lib/puck/dependency_resolver.rb
+++ b/lib/puck/dependency_resolver.rb
@@ -26,6 +26,7 @@ module Puck
           :base_path => base_path,
           :load_paths => load_paths,
           :bin_path => spec[:bindir],
+          :spec_file => spec[:spec_file],
         }
       end
     end
@@ -54,6 +55,7 @@ module Puck
                   :full_gem_path => gem_spec.full_gem_path,
                   :load_paths => gem_spec.load_paths,
                   :bindir => gem_spec.bindir,
+                  :spec_file => gem_spec.loaded_from,
                 }
               end
               Marshal.dump([specs]).to_java_bytes

--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -188,7 +188,7 @@ module Puck
           io.puts("PUCK_BIN_PATH << '#{JAR_GEM_HOME}/gems/#{spec[:versioned_name]}/#{spec[:bin_path]}'")
         end
         io.puts
-        io.puts %(Gem.paths = {'GEM_HOME'=>File.join(PUCK_ROOT, '#{JAR_GEM_HOME}')})
+        io.puts(%(Gem.paths = {'GEM_HOME' => File.join(PUCK_ROOT, '#{JAR_GEM_HOME}')}))
         io.puts
         io.puts(File.read(File.expand_path('../bootstrap.rb', __FILE__)))
       end

--- a/lib/puck/jar.rb
+++ b/lib/puck/jar.rb
@@ -144,7 +144,8 @@ module Puck
             gem_dependencies.each do |spec|
               base_path = Pathname.new(spec[:base_path]).expand_path.cleanpath
               unless project_dir == base_path
-                zipfileset dir: spec[:base_path], prefix: File.join(JAR_GEM_HOME, spec[:versioned_name])
+                zipfileset dir: spec[:base_path], prefix: File.join(JAR_GEM_HOME, 'gems', spec[:versioned_name])
+                zipfileset file: spec[:spec_file], fullpath: File.join(JAR_GEM_HOME, 'specifications', File.basename(spec[:spec_file]))
               end
             end
 
@@ -184,14 +185,10 @@ module Puck
         io.puts(%(PUCK_ROOT = JRuby.runtime.jruby_class_loader.get_resource('jar-bootstrap.rb').to_s.chomp('jar-bootstrap.rb')))
         io.puts(%(PUCK_BIN_PATH = ['#{JAR_APP_HOME}/bin', '#{JAR_JRUBY_HOME}/bin']))
         gem_dependencies.each do |spec|
-          io.puts("PUCK_BIN_PATH << '#{JAR_GEM_HOME}/#{spec[:versioned_name]}/#{spec[:bin_path]}'")
+          io.puts("PUCK_BIN_PATH << '#{JAR_GEM_HOME}/gems/#{spec[:versioned_name]}/#{spec[:bin_path]}'")
         end
         io.puts
-        gem_dependencies.each do |spec|
-          spec[:load_paths].each do |load_path|
-            io.puts(%($LOAD_PATH << File.join(PUCK_ROOT, '#{JAR_GEM_HOME}/#{spec[:versioned_name]}/#{load_path}')))
-          end
-        end
+        io.puts %(Gem.paths = {'GEM_HOME'=>File.join(PUCK_ROOT, '#{JAR_GEM_HOME}')})
         io.puts
         io.puts(File.read(File.expand_path('../bootstrap.rb', __FILE__)))
       end

--- a/spec/integration/puck_spec.rb
+++ b/spec/integration/puck_spec.rb
@@ -88,4 +88,10 @@ describe 'bin/puck' do
     output = isolated_run(jar_command('rackup -h'))
     output.should include('Usage: rackup')
   end
+
+  it 'is possible to find specific versions of gems with Kernel#gem' do
+    gem_command = 'gem("json", "=1.8.1")'
+    output = isolated_run(sprintf("echo '%s' | %s", gem_command, jar_command('irb')))
+    output.should include(sprintf("%s\ntrue\n", gem_command))
+  end
 end

--- a/spec/puck/dependency_resolver_spec.rb
+++ b/spec/puck/dependency_resolver_spec.rb
@@ -57,6 +57,12 @@ module Puck
         load_paths.grep(%r{i18n-[\d.]+/bin}).should_not be_empty
       end
 
+      it 'includes the path to the loaded gem specification' do
+        gem_spec_files = resolved_gem_dependencies.map { |gem| gem[:spec_file] }
+        gem_spec_files.grep(%r{example_dep/example_dep.gemspec}).should_not be_empty
+        gem_spec_files.grep(%r{specifications/i18n-[\d.]+.gemspec}).should_not be_empty
+      end
+
       it 'correctly handles gems with a specific platform' do
         specification = resolved_gem_dependencies.find { |gem| gem[:name] == 'puma' }
         File.basename(specification[:base_path]).should match(/puma-[\d.]+-java/)

--- a/spec/puck/jar_spec.rb
+++ b/spec/puck/jar_spec.rb
@@ -130,7 +130,7 @@ module Puck
 
           it 'sets GEM_HOME in jar-bootstrap.rb' do
             bootstrap = jar_entry_contents('jar-bootstrap.rb')
-            bootstrap.should include(%|Gem.paths = {'GEM_HOME'=>File.join(PUCK_ROOT, 'META-INF/gem.home')}|)
+            bootstrap.should include(%|Gem.paths = {'GEM_HOME' => File.join(PUCK_ROOT, 'META-INF/gem.home')}|)
           end
 
           it 'adds all gem\'s bin directories to a constant in jar-bootstrap.rb' do

--- a/spec/resources/example_app/Gemfile
+++ b/spec/resources/example_app/Gemfile
@@ -5,6 +5,7 @@ gemspec name: 'example'
 gem 'puma'
 gem 'rack-contrib', git: 'https://github.com/rack/rack-contrib.git'
 gem 'qu-redis'
+gem 'json', '= 1.8.1'
 
 gem 'puck-example_dep', path: '../example_dep'
 

--- a/spec/resources/example_app/Gemfile.lock
+++ b/spec/resources/example_app/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     hashie (2.0.4)
     i18n (0.6.1)
     jruby-jars (1.7.11)
+    json (1.8.1-java)
     method_source (0.8.1)
     multi_json (1.7.2)
     multi_xml (0.5.3)
@@ -96,6 +97,7 @@ PLATFORMS
 
 DEPENDENCIES
   jruby-jars (= 1.7.11)
+  json (= 1.8.1)
   pry
   puck!
   puck-example_app!


### PR DESCRIPTION
Currently, the paths of the user installed gems are appended to `$LOAD_PATH`, which means that they'll be searched after the built-in gems in `/META-INF/jruby.home/lib/ruby/*`. This means that the built-in gems will be preferred to the user installed ones, which is not the desired behavior. Thus, this PR suggests that we change the order of the `$LOAD_PATH` so that user installed gems are preferred.

I've implemented a test for this which is brittle at best, but I couldn't think of a better way to test this.

I chose to preserve the internal order of the user installed gems, as I didn't know whether it was significant or not. If it isn't, a much simpler solution would be to prepend the paths to `$LOAD_PATH` using `#unshift` instead.