### PR TITLE
Bundler workarounds, take 99

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,4 @@
 -I lib
 --color
 --format doc
-spec
+--pattern 'spec/{puck,integration}/*_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,4 @@ group :test do
   gem 'jruby-jars', '= 1.7.12'
   gem 'rspec', '~> 2.14', '< 2.99'
   gem 'simplecov'
-  gem 'coveralls'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -4,16 +4,14 @@ require 'bundler'
 require 'bundler/setup'
 require 'rspec/core/rake_task'
 
-EXAMPLE_APP_BUNDLE_PATH = File.expand_path('../vendor/example_app-bundle', __FILE__)
 EXAMPLE_APP_HOME = File.expand_path('../spec/resources/example_app', __FILE__)
 
 task :setup do
-  Bundler.clean_system("bundle install --without=not_installed --retry=3 --gemfile=#{EXAMPLE_APP_HOME}/Gemfile --path=#{EXAMPLE_APP_BUNDLE_PATH} --binstubs=#{EXAMPLE_APP_HOME}/.bundle/bin")
-  rm_rf File.join(EXAMPLE_APP_HOME, '.bundle/config')
+  Bundler.clean_system("bundle install --without=not_installed --retry=3 --gemfile=#{EXAMPLE_APP_HOME}/Gemfile --path=#{EXAMPLE_APP_HOME}/vendor/bundle --binstubs=#{EXAMPLE_APP_HOME}/.bundle/bin")
 end
 
 task :clean do
-  [File.join(EXAMPLE_APP_HOME, '.bundle'), EXAMPLE_APP_BUNDLE_PATH].each do |path|
+  [File.join(EXAMPLE_APP_HOME, '.bundle'), File.join(EXAMPLE_APP_HOME, 'vendor')].each do |path|
     rm_rf(path)
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,7 @@ end
 
 RSpec::Core::RakeTask.new(:spec) do |r|
   r.rspec_opts = '--tty'
+  r.pattern = 'spec/{puck,integration}/**/*_spec.rb'
 end
 
 task :spec => :setup

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require 'rspec/core/rake_task'
 EXAMPLE_APP_HOME = File.expand_path('../spec/resources/example_app', __FILE__)
 
 task :setup do
-  Bundler.clean_system("bundle install --without=not_installed --retry=3 --gemfile=#{EXAMPLE_APP_HOME}/Gemfile --path=#{EXAMPLE_APP_HOME}/vendor/bundle --binstubs=#{EXAMPLE_APP_HOME}/.bundle/bin")
+  Bundler.clean_system("bundle install --without=not_installed --retry=3 --gemfile=#{EXAMPLE_APP_HOME}/Gemfile --path=#{EXAMPLE_APP_HOME}/vendor/bundle --binstubs=#{EXAMPLE_APP_HOME}/vendor/bin")
 end
 
 task :clean do

--- a/lib/puck/dependency_resolver.rb
+++ b/lib/puck/dependency_resolver.rb
@@ -35,10 +35,11 @@ module Puck
 
     def contained_bundler(gem_home, gemfile, lockfile, groups)
       Bundler.with_clean_env do
+        env = ENV.merge('BUNDLE_GEMFILE' => gemfile, 'BUNDLE_PATH' => gem_home, 'GEM_HOME' => gem_home)
         scripting_container = Java::OrgJrubyEmbed::ScriptingContainer.new(Java::OrgJrubyEmbed::LocalContextScope::SINGLETHREAD)
         scripting_container.compat_version = Java::OrgJruby::CompatVersion::RUBY1_9
         scripting_container.current_directory = Dir.pwd
-        scripting_container.environment = Hash[ENV.merge('GEM_HOME' => gem_home).map { |k,v| [k.to_java, v.to_java] }]
+        scripting_container.environment = Hash[env.map { |k,v| [k.to_java, v.to_java] }]
         scripting_container.put('arguments', Marshal.dump([gemfile, lockfile, groups]).to_java_bytes)
         begin
           line = __LINE__ + 1 # as __LINE__ represents next statement line i JRuby, and that becomes difficult to offset

--- a/lib/puck/dependency_resolver.rb
+++ b/lib/puck/dependency_resolver.rb
@@ -11,7 +11,7 @@ module Puck
       groups = options[:gem_groups] || [:default]
 
       bundler_specs = contained_bundler(gem_home, gemfile, lockfile, groups)
-      bundler_specs.delete_if { |spec| spec[:name] == 'bundler' }
+      bundler_specs.delete_if { |spec| spec[:name] == 'bundler' || spec[:name] == 'puck' }
       bundler_specs.map do |spec|
         base_path = spec[:full_gem_path].chomp('/')
         load_paths = spec[:load_paths].map do |load_path|

--- a/lib/puck/dependency_resolver.rb
+++ b/lib/puck/dependency_resolver.rb
@@ -48,7 +48,7 @@ module Puck
               require 'bundler'
               gemfile, lockfile, groups = Marshal.load(String.from_java_bytes(arguments))
               definition = Bundler::Definition.build(gemfile, lockfile, false)
-              ENV['BUNDLE_WITHOUT'] = (definition.groups - groups).join(':')
+              Bundler.settings[:without] = (definition.groups - groups).join(':')
               specs = definition.specs.map do |gem_spec|
                 {
                   :name => gem_spec.name,

--- a/lib/puck/dependency_resolver.rb
+++ b/lib/puck/dependency_resolver.rb
@@ -66,7 +66,8 @@ module Puck
           EOS
           result, error, backtrace = Marshal.load(String.from_java_bytes(unit.run))
           if error
-            raise error, Array(backtrace) + caller
+            error.set_backtrace(Array(backtrace) + caller)
+            raise error
           end
           result
         ensure

--- a/spec/integration/puck_spec.rb
+++ b/spec/integration/puck_spec.rb
@@ -27,7 +27,7 @@ describe 'bin/puck' do
       'BUNDLE_PATH' => File.join('vendor/bundle/jruby', RbConfig::CONFIG['ruby_version']),
       'BUNDLE_WITHOUT' => 'not_installed',
     }
-    isolated_run([env, '.bundle/bin/puck', '--extra-files', 'config/app.yml', '--merge-archives', '../../resources/fake-external.jar'])
+    isolated_run([env, 'bundle', 'exec', 'puck', '--extra-files', 'config/app.yml', '--merge-archives', '../../resources/fake-external.jar'])
   end
 
   it 'creates a self-contained Jar that exposes the app\'s bin files' do

--- a/spec/integration/puck_spec.rb
+++ b/spec/integration/puck_spec.rb
@@ -23,7 +23,8 @@ describe 'bin/puck' do
     FileUtils.rm_rf File.join(APP_DIR, 'build')
     env = {
       'BUNDLE_GEMFILE' => 'Gemfile',
-      'BUNDLE_PATH' => File.join('../../../vendor/example_app-bundle/jruby', RbConfig::CONFIG['ruby_version']),
+      'GEM_HOME' => File.join('vendor/bundle/jruby', RbConfig::CONFIG['ruby_version']),
+      'BUNDLE_PATH' => File.join('vendor/bundle/jruby', RbConfig::CONFIG['ruby_version']),
       'BUNDLE_WITHOUT' => 'not_installed',
     }
     isolated_run([env, '.bundle/bin/puck', '--extra-files', 'config/app.yml', '--merge-archives', '../../resources/fake-external.jar'])

--- a/spec/puck/dependency_resolver_spec.rb
+++ b/spec/puck/dependency_resolver_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'spec_helper'
+require 'yaml'
 
 
 module Puck

--- a/spec/puck/dependency_resolver_spec.rb
+++ b/spec/puck/dependency_resolver_spec.rb
@@ -95,8 +95,13 @@ module Puck
         specifications.should have(1).specification
       end
 
-      it 'should not include bundler itself' do
+      it 'does not include Bundler' do
         specification = resolved_gem_dependencies.find { |gem| gem[:name] == 'bundler' }
+        specification.should be_nil
+      end
+
+      it 'does not include Puck' do
+        specification = resolved_gem_dependencies.find { |gem| gem[:name] == 'puck' }
         specification.should be_nil
       end
 

--- a/spec/puck/dependency_resolver_spec.rb
+++ b/spec/puck/dependency_resolver_spec.rb
@@ -17,7 +17,7 @@ module Puck
       end
 
       let :gem_home do
-        File.expand_path(File.join('../../../vendor/example_app-bundle/jruby', RbConfig::CONFIG['ruby_version']), app_dir_path)
+        File.join(app_dir_path, 'vendor/bundle/jruby', RbConfig::CONFIG['ruby_version'])
       end
 
       let :options do

--- a/spec/puck/dependency_resolver_spec.rb
+++ b/spec/puck/dependency_resolver_spec.rb
@@ -115,13 +115,16 @@ module Puck
           gem_names.should include('regal', 'rack-cache')
         end
 
-        it 'does not change the bundle configuration' do
+        it 'does not modify the bundle config' do
+          options[:gem_groups] = [:not_installed]
+          resolved_gem_dependencies rescue nil
           bundler_config_path = File.join(app_dir_path, '.bundle', 'config')
-          expect {
-            resolved_gem_dependencies
-          }.to_not change {
-            File.exist?(bundler_config_path) ? File.read(bundler_config_path) : nil
-          }
+          if File.exist?(bundler_config_path)
+            config = YAML.load_file(bundler_config_path)
+            if without = config['BUNDLE_WITHOUT']
+              without.should eq('not_installed')
+            end
+          end
         end
       end
     end

--- a/spec/puck/dependency_resolver_spec.rb
+++ b/spec/puck/dependency_resolver_spec.rb
@@ -28,14 +28,14 @@ module Puck
 
       it 'includes the gem name in the specification' do
         gem_names = resolved_gem_dependencies.map { |gem| gem[:name] }
-        gem_names.should include('grape')
-        gem_names.should include('i18n')
+        gem_names.should include('regal')
+        gem_names.should include('redis-namespace')
       end
 
       it 'includes the versioned gem name in the specification' do
         versioned_gem_names = resolved_gem_dependencies.map { |gem| gem[:versioned_name] }
-        versioned_gem_names.grep(/grape-[\d.]+/).should_not be_empty
-        versioned_gem_names.grep(/i18n-[\d.]+/).should_not be_empty
+        versioned_gem_names.grep(/regal-[\d.]+/).should_not be_empty
+        versioned_gem_names.grep(/redis-namespace-[\d.]+/).should_not be_empty
       end
 
       it 'includes the gem\'s base path in the specification' do
@@ -47,20 +47,20 @@ module Puck
 
       it 'includes relative loads paths in the specification' do
         load_paths = resolved_gem_dependencies.flat_map { |gem| gem[:load_paths].map { |load_path| File.join(gem[:versioned_name], load_path) } }
-        load_paths.grep(%r{grape-[\d.]+/lib}).should_not be_empty
-        load_paths.grep(%r{i18n-[\d.]+/lib}).should_not be_empty
+        load_paths.grep(%r{regal-[\d.]+/lib}).should_not be_empty
+        load_paths.grep(%r{redis-namespace-[\d.]+/lib}).should_not be_empty
       end
 
       it 'includes the relative bin path in the specification' do
         load_paths = resolved_gem_dependencies.map { |gem| File.join(gem[:versioned_name], gem[:bin_path]) }
-        load_paths.grep(%r{grape-[\d.]+/bin}).should_not be_empty
-        load_paths.grep(%r{i18n-[\d.]+/bin}).should_not be_empty
+        load_paths.grep(%r{regal-[\d.]+/bin}).should_not be_empty
+        load_paths.grep(%r{redis-namespace-[\d.]+/bin}).should_not be_empty
       end
 
       it 'includes the path to the loaded gem specification' do
         gem_spec_files = resolved_gem_dependencies.map { |gem| gem[:spec_file] }
         gem_spec_files.grep(%r{example_dep/example_dep.gemspec}).should_not be_empty
-        gem_spec_files.grep(%r{specifications/i18n-[\d.]+.gemspec}).should_not be_empty
+        gem_spec_files.grep(%r{specifications/redis-namespace-[\d.]+.gemspec}).should_not be_empty
       end
 
       it 'correctly handles gems with a specific platform' do
@@ -107,7 +107,7 @@ module Puck
 
         it 'includes gems from the specified groups' do
           gem_names = resolved_gem_dependencies.map { |gem| gem[:name] }
-          gem_names.should include('grape', 'rack-cache')
+          gem_names.should include('regal', 'rack-cache')
         end
 
         it 'does not write a bundle configuration' do

--- a/spec/puck/dependency_resolver_spec.rb
+++ b/spec/puck/dependency_resolver_spec.rb
@@ -115,9 +115,13 @@ module Puck
           gem_names.should include('regal', 'rack-cache')
         end
 
-        it 'does not write a bundle configuration' do
-          bundler_config = Pathname.new(app_dir_path).join('.bundle', 'config')
-          bundler_config.should_not exist
+        it 'does not change the bundle configuration' do
+          bundler_config_path = File.join(app_dir_path, '.bundle', 'config')
+          expect {
+            resolved_gem_dependencies
+          }.to_not change {
+            File.exist?(bundler_config_path) ? File.read(bundler_config_path) : nil
+          }
         end
       end
     end

--- a/spec/resources/example_app/Gemfile
+++ b/spec/resources/example_app/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org/'
 
-gemspec name: 'example'
+gemspec
 
 gem 'puma'
 gem 'rack-contrib', git: 'https://github.com/rack/rack-contrib.git'

--- a/spec/resources/example_app/Gemfile.lock
+++ b/spec/resources/example_app/Gemfile.lock
@@ -6,12 +6,6 @@ GIT
       rack (>= 0.9.1)
 
 PATH
-  remote: .
-  specs:
-    puck-example_app (0.0.1-java)
-      grape
-
-PATH
   remote: ../../..
   specs:
     puck (1.2.2-java)
@@ -21,35 +15,22 @@ PATH
   specs:
     puck-example_dep (0.0.1-java)
 
+PATH
+  remote: .
+  specs:
+    puck-example_app (0.0.1-java)
+      regal
+
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.13)
-      i18n (= 0.6.1)
-      multi_json (~> 1.0)
-    backports (2.6.7)
-    builder (3.2.0)
     coderay (1.0.9)
-    descendants_tracker (0.0.1)
     diff-lcs (1.2.4)
     ffi (1.8.1-java)
-    grape (0.4.1)
-      activesupport
-      builder
-      hashie (>= 1.2.0)
-      multi_json (>= 1.3.2)
-      multi_xml (>= 0.5.2)
-      rack (>= 1.3.0)
-      rack-accept
-      rack-mount
-      virtus
-    hashie (2.0.4)
-    i18n (0.6.1)
     jruby-jars (1.7.11)
     json (1.8.1-java)
     method_source (0.8.1)
     multi_json (1.7.2)
-    multi_xml (0.5.3)
     pry (0.9.12.1-java)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -64,18 +45,16 @@ GEM
       redis-namespace
       simple_uuid
     rack (1.5.2)
-    rack-accept (0.4.5)
-      rack (>= 0.4)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-mini-profiler (0.9.2)
       rack (>= 1.1.3)
-    rack-mount (0.8.3)
-      rack (>= 1.0.0)
     rake (10.3.2)
     redis (3.1.0)
     redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
+    regal (0.2.0)
+      rack (~> 1.5)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -88,9 +67,6 @@ GEM
     slop (3.4.4)
     spoon (0.0.3)
       ffi
-    virtus (0.5.4)
-      backports (~> 2.6.1)
-      descendants_tracker (~> 0.0.1)
 
 PLATFORMS
   java

--- a/spec/resources/example_app/Gemfile.lock
+++ b/spec/resources/example_app/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: ../../..
   specs:
-    puck (1.2.2-java)
+    puck (1.2.4-java)
 
 PATH
   remote: ../example_dep
@@ -85,3 +85,6 @@ DEPENDENCIES
   rack-mini-profiler
   rake
   rspec
+
+BUNDLED WITH
+   1.13.1

--- a/spec/resources/example_app/example.gemspec
+++ b/spec/resources/example_app/example.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.default_executable = 'server'
   s.executables        = [s.default_executable]
 
-  s.add_dependency 'grape'
+  s.add_dependency 'regal'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,14 +4,8 @@ require 'bundler/setup'
 require 'tmpdir'
 require 'support/rewind_in_jars'
 
-unless ENV['COVERAGE'] == 'no'
-  require 'coveralls'
+unless ENV['COVERAGE'] == 'no' || ENV.include?('TRAVIS')
   require 'simplecov'
-
-  if ENV.include?('TRAVIS')
-    Coveralls.wear!
-    SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-  end
 
   SimpleCov.start do
     add_group 'Source', 'lib'


### PR DESCRIPTION
Bundler keeps breaking things randomly, luckily it seems like it's just the tests that have broken recently. Getting an isolated environment to run the tests in is really, really hard.

This is a collection of fixes that seem to patch things together again:
- I've thrown out Grape as a dependency of the example app, it had a little bit too big of a blast radius. The tests blew up because of `descendants_tracker` not being able to do something and I couldn't even figure out why it was even involved since it was a dependency of the example app, not Puck itself.
- The example app bundle is not vendored inside of the examples app directory. Bundler kept trying to find caches and other things under the example app directory, I just don't think Bundler supports having the bundle outside of the app directory anymore, but who knows? This means that the pattern given to RSpec needs to be more restrictive, otherwise it matches things the vendored gems of the example app.
- I had to remove Puck from the jar. I think that originally we excluded it, but then started including it, but I'm not sure why. Either way I got "stack level too deep" errors when it was included.
- Setting `BUNDLE_WITHOUT` after Bundler has loaded doesn't seem to work anymore, you need to do `Bundler.settings[:without] = …`. Since Bundler is your best friend this will also rewrite the config. I solved this very inelegantly by making a backup of the config before running the dependency resolution and then putting it back again after. I can't see any way to stop Bundler from writing the config.

There might be better ways to solve these problems, but I've already wasted five hours of my life. Suggestions are welcome.
